### PR TITLE
Fixing bug in header

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,3 +13,4 @@ LinkingTo:
     Rcpp
 Imports: 
     Rcpp
+RoxygenNote: 6.0.1

--- a/header.reprex.Rproj
+++ b/header.reprex.Rproj
@@ -18,3 +18,4 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace

--- a/src/timesthree.h
+++ b/src/timesthree.h
@@ -1,5 +1,5 @@
-#ifndef MODSTRING_H
-#define MODSTRING_H
+#ifndef TIMESTHREE
+#define TIMESTHREE
 
 #include <Rcpp.h>
 Rcpp::NumericVector timesThree(Rcpp::NumericVector x);

--- a/src/timestwo.h
+++ b/src/timestwo.h
@@ -1,5 +1,5 @@
-#ifndef MODSTRING_H
-#define MODSTRING_H
+#ifndef TIMESTWO
+#define TIMESTWO
 
 #include <Rcpp.h>
 Rcpp::NumericVector timesTwo(Rcpp::NumericVector x);


### PR DESCRIPTION
The #ifndef macro was defined in the wrong way. The idea is that you should have one #ifndef macro value per header. This tells the compiler whether that part of code was already defined, so essentially what happened was that, as `MODSTRING_H` was already defined in `timestwo.h`, the compiler was skipping the code in `timesthree.h`. Now is fixed

HIH